### PR TITLE
Remove blank space at top of pages

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -1,0 +1,5 @@
+{% extends "juice/templates/page.html" %}
+
+{% block content %}
+	{{ page.content | safe }}
+{% endblock content %}


### PR DESCRIPTION
Caused by an empty text element, overrode by removing heading text element