### PR TITLE
Add Outlook Calendar to Ministry

### DIFF
--- a/content/ministry.md
+++ b/content/ministry.md
@@ -6,4 +6,11 @@ title="Ministry"
 
 ## Bible Study Schedule for 2025
 
-<iframe src="https://outlook.office365.com/owa/calendar/7b5021067f834f2b9c74592b211bd7a1@gcfpeel.ca/ae2761dc583d47b59bd32c9a20068df08689724020298912608/calendar.html" style="border:0px #ffffff none;" name="YYA Calendar" scrolling="no" frameborder="1" marginheight="0px" marginwidth="0px" height="1000" width="1050"></iframe>
+<iframe id="open-web-calendar" 
+    style="background:url('https://raw.githubusercontent.com/niccokunzmann/open-web-calendar/master/static/img/loaders/circular-loader.gif') center center no-repeat;"
+    src="https://icsviewer.ecam.fr/calendar.html?start_of_week=su&amp;target=_blank&amp;timezone=America%2FToronto&amp;title=Youth%20%26%20Young%20Adults%20Ministry%20Calendar&amp;url=https%3A%2F%2Foutlook.office365.com%2Fowa%2Fcalendar%2F7b5021067f834f2b9c74592b211bd7a1%40gcfpeel.ca%2Fae2761dc583d47b59bd32c9a20068df08689724020298912608%2Fcalendar.ics"
+    sandbox="allow-scripts allow-same-origin allow-popups"
+    allowTransparency="true" scrolling="no" 
+    frameborder="0" height="600px" width="100%"></iframe>
+
+You can also download the calendar as an [iCal](https://outlook.office365.com/owa/calendar/7b5021067f834f2b9c74592b211bd7a1@gcfpeel.ca/ae2761dc583d47b59bd32c9a20068df08689724020298912608/calendar.ics)

--- a/content/ministry.md
+++ b/content/ministry.md
@@ -4,8 +4,6 @@ title="Ministry"
 
 # Youth and Young Adult Ministry
 
-## Bible Study Schedule for 2025
-
 <iframe id="open-web-calendar" 
     style="background:url('https://raw.githubusercontent.com/niccokunzmann/open-web-calendar/master/static/img/loaders/circular-loader.gif') center center no-repeat;"
     src="https://icsviewer.ecam.fr/calendar.html?start_of_week=su&amp;target=_blank&amp;timezone=America%2FToronto&amp;title=Youth%20%26%20Young%20Adults%20Ministry%20Calendar&amp;tabs=month&amp;tabs=week&amp;tabs=day&amp;tabs=agenda&amp;url=https%3A%2F%2Foutlook.office365.com%2Fowa%2Fcalendar%2F7b5021067f834f2b9c74592b211bd7a1%40gcfpeel.ca%2Fae2761dc583d47b59bd32c9a20068df08689724020298912608%2Fcalendar.ics"

--- a/content/ministry.md
+++ b/content/ministry.md
@@ -5,8 +5,5 @@ title="Ministry"
 # Youth and Young Adult Ministry
 
 ## Bible Study Schedule for 2025
-| Date        | Location    | Time (Eastern Time) |
-| :---------------- | :------------------------ | :------------------ |
-| Feb. 7, 2025    | Meadowvale CC | 7:30 PM to 9:00 PM |
-| Feb. 21, 2025   | Meadowvale CC | 7:30 PM to 9:00 PM |
-| Mar. 21, 2025   | Meadowvale CC | 7:30 PM to 9:00 PM |
+
+<iframe src="https://outlook.office365.com/owa/calendar/7b5021067f834f2b9c74592b211bd7a1@gcfpeel.ca/ae2761dc583d47b59bd32c9a20068df08689724020298912608/calendar.html" style="border:0px #ffffff none;" name="YYA Calendar" scrolling="no" frameborder="1" marginheight="0px" marginwidth="0px" height="1000" width="1050"></iframe>

--- a/content/ministry.md
+++ b/content/ministry.md
@@ -4,6 +4,8 @@ title="Ministry"
 
 # Youth and Young Adult Ministry
 
+## Upcoming Events
+
 <iframe id="open-web-calendar" 
     style="background:url('https://raw.githubusercontent.com/niccokunzmann/open-web-calendar/master/static/img/loaders/circular-loader.gif') center center no-repeat;"
     src="https://icsviewer.ecam.fr/calendar.html?start_of_week=su&amp;target=_blank&amp;timezone=America%2FToronto&amp;title=Youth%20%26%20Young%20Adults%20Ministry%20Calendar&amp;tabs=month&amp;tabs=week&amp;tabs=day&amp;tabs=agenda&amp;url=https%3A%2F%2Foutlook.office365.com%2Fowa%2Fcalendar%2F7b5021067f834f2b9c74592b211bd7a1%40gcfpeel.ca%2Fae2761dc583d47b59bd32c9a20068df08689724020298912608%2Fcalendar.ics"

--- a/content/ministry.md
+++ b/content/ministry.md
@@ -8,7 +8,7 @@ title="Ministry"
 
 <iframe id="open-web-calendar" 
     style="background:url('https://raw.githubusercontent.com/niccokunzmann/open-web-calendar/master/static/img/loaders/circular-loader.gif') center center no-repeat;"
-    src="https://icsviewer.ecam.fr/calendar.html?start_of_week=su&amp;target=_blank&amp;timezone=America%2FToronto&amp;title=Youth%20%26%20Young%20Adults%20Ministry%20Calendar&amp;url=https%3A%2F%2Foutlook.office365.com%2Fowa%2Fcalendar%2F7b5021067f834f2b9c74592b211bd7a1%40gcfpeel.ca%2Fae2761dc583d47b59bd32c9a20068df08689724020298912608%2Fcalendar.ics"
+    src="https://icsviewer.ecam.fr/calendar.html?start_of_week=su&amp;target=_blank&amp;timezone=America%2FToronto&amp;title=Youth%20%26%20Young%20Adults%20Ministry%20Calendar&amp;tabs=month&amp;tabs=week&amp;tabs=day&amp;tabs=agenda&amp;url=https%3A%2F%2Foutlook.office365.com%2Fowa%2Fcalendar%2F7b5021067f834f2b9c74592b211bd7a1%40gcfpeel.ca%2Fae2761dc583d47b59bd32c9a20068df08689724020298912608%2Fcalendar.ics"
     sandbox="allow-scripts allow-same-origin allow-popups"
     allowTransparency="true" scrolling="no" 
     frameborder="0" height="600px" width="100%"></iframe>


### PR DESCRIPTION
This changes the ministry calendar that was text based, to an updated, reactive Outlook Calendar.

Some things to note:
1. This might start the view all the way to the default start (which is Dec 1899), that might be an Outlook or me thing, but you can click on "Today".
2. I set the size to 1000x1050, I tried my best to make it viewable on both pc and mobile, if you want to do some more Iframe changes, be my guest, this was just googling.
3. To do some edits on the calendar, you will need to access the ministry shared mailbox, then Calendars. Reach out to me if you are unable to access it (or, grant yourself access if you know how to)

EDIT:
This now uses an Open Calendar Framework instead of the existing Outlook HTML Calendar, as that kept producing issues.